### PR TITLE
Changed password validation to use login endpoint

### DIFF
--- a/macOS-x64/darwin/Resources/login.py
+++ b/macOS-x64/darwin/Resources/login.py
@@ -4,15 +4,15 @@ import PySimpleGUI as sg
 import requests
 
 def verify_password(user, password):
-    # r = requests.get("https://vgyc6fujod.execute-api.us-east-1.amazonaws.com/prod/enroll", params={"email": user, "password": password})
-    if (user == "admin" and password == "admin"):
+    r = requests.put("https://vgyc6fujod.execute-api.us-east-1.amazonaws.com/prod/login", json={"email": user, "password": password})
+    if (r.json()['accepted'] == "True"):
         return True
     else:
         print("incorrect login")
         return False
 
 layout = [  [sg.Text('Username'), sg.Input(key='-USERNAME-')],
-            [sg.Text('Password'), sg.Input(key='-PASSWORD-')],
+            [sg.Text('Password'), sg.Input(key='-PASSWORD-', password_char='*')],
             [sg.Text(''), sg.Text(size=(50,1), key='-mytext-', text_color='red')],
             [sg.Button('Ok', key='-OK-'), sg.Cancel()],
             [sg.Button('Submit', visible=False, bind_return_key=True)]


### PR DESCRIPTION
Changed the login.py script to hit the /login endpoint Henry created to correctly validate user credentials in the installer. Also hides passwords when users are typing in the login popup window.